### PR TITLE
Make TEST_ENV mode usable end-to-end

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,14 @@ FROM python:3.12.11-slim
 # Set the working directory in the container
 WORKDIR /usr/src/app
 
-# Install system dependencies required for psycopg2 or other PostgreSQL interactions
-RUN apt-get update && apt-get install -y \
+# Install system dependencies required for psycopg2 or other PostgreSQL interactions.
+# `docker.io` provides the docker CLI, which the coordinator invokes via
+# subprocess in TEST_ENV mode to spawn worker containers.
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq-dev \
     libpq5 \
     build-essential \
+    docker.io \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy the current directory contents into the container at /usr/src/app

--- a/uptime_service_validation/coordinator/server.py
+++ b/uptime_service_validation/coordinator/server.py
@@ -355,6 +355,13 @@ def setUpValidatorProcesses(time_intervals, logging, worker_image, worker_tag):
             "AWS_S3_BUCKET",
             "-e",
             "AWS_REGION",
+            # Forwarded for S3-compatible storage emulation (MinIO, LocalStack)
+            # in TEST_ENV mode. Production AWS deployments leave both unset, so
+            # workers fall back to the SDK default (real AWS S3, virtual-hosted).
+            "-e",
+            "AWS_ENDPOINT_URL_S3",
+            "-e",
+            "AWS_S3_FORCE_PATH_STYLE",
             "-e",
             f"NETWORK_NAME={Config.NETWORK_NAME}",
             "-e",


### PR DESCRIPTION
## Summary

Two small fixes that together make the coordinator's `TEST_ENV=1` path actually exercisable. Each is independently a no-op for production deployments — gates are env-var-controlled and additive.

### 1. Add `docker.io` to the validation image

The TEST_ENV path in `setUpValidatorProcesses` spawns worker containers via `subprocess.Popen(['docker', 'run', ...])`, but the image had no docker CLI installed. Result: `FileNotFoundError: [Errno 2] No such file or directory: 'docker'` before any worker spawned. Adding `docker.io` (with `--no-install-recommends` to keep the image lean) lets the subprocess find the binary; the daemon is still provided by the host via the mounted `/var/run/docker.sock`.

### 2. Forward `AWS_ENDPOINT_URL_S3` + `AWS_S3_FORCE_PATH_STYLE` to spawned workers

The `docker run` command in `server.py` builds an explicit `-e` passthrough list. The coordinator can be pointed at MinIO/LocalStack via these env vars, but workers — running in a separate container — only see what's explicitly forwarded. Without these two passthroughs, workers fall through to real AWS S3 and fail with `InvalidAccessKeyId`. Forward both. (Same shape as [`uptime-service-backend` PR #9](https://github.com/o1-labs/uptime-service-backend/pull/9), which added the same env-var support there.)

## Backward compatibility

- Production AWS deployments leave `AWS_ENDPOINT_URL_S3` and `AWS_S3_FORCE_PATH_STYLE` unset. The `-e` passthrough then forwards an empty/unset variable, which the SDK ignores — same behavior as today.
- Image size grows by the size of `docker.io` (~25 MB). Acceptable for the unblock.

## Motivation

Required by [`uptime-service-e2e`](https://github.com/o1-labs/uptime-service-e2e) so the harness can extend its contract from "submission lands in storage" to "submission gets verified by the coordinator end-to-end" — fully against MinIO, no real AWS credentials needed in CI.

## Test plan

- [x] Validation image rebuilds with docker.io and no breakage
- [x] In `uptime-service-e2e` (with this image): coordinator successfully spawns 23 worker containers via DinD socket; workers run, query Postgres, exit cleanly
- [x] Worker `submission-updater` shows `Number of returned submissions: 0` for empty batches (sanity check that S3 queries weren't reached/failed)
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)