### PR TITLE
Fix: install docker CLI via recommends, not just docker.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,10 @@ WORKDIR /usr/src/app
 
 # Install system dependencies required for psycopg2 or other PostgreSQL interactions.
 # `docker.io` provides the docker CLI, which the coordinator invokes via
-# subprocess in TEST_ENV mode to spawn worker containers.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# subprocess in TEST_ENV mode to spawn worker containers. Recommends are
+# required: on Debian's slim base the CLI binary (/usr/bin/docker) ships in
+# a recommended package, not in docker.io itself.
+RUN apt-get update && apt-get install -y \
     libpq-dev \
     libpq5 \
     build-essential \


### PR DESCRIPTION
## Summary

v2.0.9 (PR #6) added \`docker.io\` to the validation image so TEST_ENV's \`subprocess.Popen(['docker', 'run', ...])\` would have a binary to call. It also added \`--no-install-recommends\` to keep the image lean — but on Debian's python:slim base, that flag silently strips the actual \`docker\` CLI binary, which ships in a recommended package rather than in \`docker.io\` proper.

Verified inside the published \`v2.0.9\`:

\`\`\`
$ dpkg -L docker.io | grep -E 'bin/'
/usr/sbin/docker-proxy
/usr/sbin/dockerd
/usr/bin/docker-init
\`\`\`

Notice: no \`/usr/bin/docker\`. The daemon binaries are present (which we don't use — we mount the host's docker socket), but the CLI we actually call is missing.

The fix is one word: drop \`--no-install-recommends\` from this RUN line.

## Cost

Image grows by ~50 MB of recommended packages (apparmor, cgroupfs-mount, init helpers, etc.). All harmless when the daemon isn't running. Acceptable to keep TEST_ENV functional.

## Verification

\`\`\`
$ docker run --rm python:3.12.11-slim sh -c "apt-get update -qq && apt-get install -y -qq docker.io && which docker && docker --version"
/usr/bin/docker
Docker version 26.1.5+dfsg1, build a72d7cd
\`\`\`

## Test plan

- [x] Manual: \`docker.io\` install in fresh \`python:3.12.11-slim\` container → \`/usr/bin/docker\` present
- [ ] CI tests pass
- [ ] After merge + new tag, run \`uptime-service-e2e\` validation flow end-to-end (currently blocked by this issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)