### PR TITLE
ci: add image smoke tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,3 +41,22 @@ jobs:
     - name: 🛠️ Build Docker image
       run: |
         docker build -t uptime-service-validation .
+
+    - name: 🚬 Smoke-test image
+      run: |
+        set -euo pipefail
+        IMAGE=uptime-service-validation
+
+        # The coordinator's TEST_ENV branch shells out to `docker run` to
+        # spawn worker containers, so the CLI must be on PATH inside the
+        # image. v2.0.9 shipped without it (the daemon was installed but
+        # the CLI binary was dropped by --no-install-recommends); this
+        # check catches that class of regression in 5 seconds.
+        docker run --rm "$IMAGE" sh -c "command -v docker && docker --version"
+
+        # `poetry run start` is the image's CMD; both must be on PATH.
+        docker run --rm "$IMAGE" sh -c "command -v poetry"
+
+        # Coordinator entrypoint module must import without runtime errors.
+        # Catches accidental syntax breaks, missing deps, broken imports.
+        docker run --rm "$IMAGE" python -c "from uptime_service_validation.coordinator import coordinator"


### PR DESCRIPTION
## Summary

Adds three small smoke checks to the existing CI build job, run against the freshly-built validation image right after `docker build`. Each takes a couple of seconds and gates PRs before merge.

| Check | What it catches |
|---|---|
| `command -v docker && docker --version` | Missing or broken docker CLI in the image |
| `command -v poetry` | Missing Poetry (image's CMD is `poetry run start`) |
| `python -c "from uptime_service_validation.coordinator import coordinator"` | Import-time errors, missing deps, syntax breaks |

## Motivation

We just shipped v2.0.9 without a working `docker` CLI inside the image. The bug: PR #6 added `docker.io` to the apt install but with `--no-install-recommends`, which silently drops the CLI binary on Debian's slim base. Tag was cut, image published, and only the next live e2e run caught it — costing a release cycle to put out v2.0.10 with the fix.

The first check above runs `docker --version` against the built image. It would have failed in 5 seconds and blocked the merge of PR #6 before the broken Dockerfile reached `main`.

## Test plan

- [x] CI job triggers on this PR (the new step appears in the run)
- [ ] Smoke step passes against the current Dockerfile (which has the fix from PR #7 baked in)
- [ ] Locally: `docker build -t test . && docker run --rm test sh -c 'command -v docker && command -v poetry'` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)