### PR TITLE
config: read POSTGRES_* lazily, validate at startup

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,14 +1,13 @@
 import os
 
-# required environment variables
-os.environ["RETRY_COUNT"] = "3"
-os.environ["SURVEY_INTERVAL_MINUTES"] = "3"
-os.environ["MINI_BATCH_NUMBER"] = "3"
-os.environ["UPTIME_DAYS_FOR_SCORE"] = "3"
-os.environ["WORKER_IMAGE"] = "test_image"
-os.environ["WORKER_TAG"] = "test_tag"
-os.environ["POSTGRES_HOST"] = "test_host"
-os.environ["POSTGRES_DB"] = "test_db"
-os.environ["POSTGRES_USER"] = "test_user"
-os.environ["POSTGRES_PASSWORD"] = "test_password"
-os.environ["POSTGRES_PORT"] = "5432"
+# Default values for tests that touch Config attributes which still have
+# `.get(..., default)` semantics in production but where a specific value is
+# convenient. POSTGRES_* are no longer set here — Config reads them lazily
+# via os.environ.get and validates presence at startup, so tests that don't
+# exercise the Postgres path don't need them.
+os.environ.setdefault("RETRY_COUNT", "3")
+os.environ.setdefault("SURVEY_INTERVAL_MINUTES", "3")
+os.environ.setdefault("MINI_BATCH_NUMBER", "3")
+os.environ.setdefault("UPTIME_DAYS_FOR_SCORE", "3")
+os.environ.setdefault("WORKER_IMAGE", "test_image")
+os.environ.setdefault("WORKER_TAG", "test_tag")

--- a/uptime_service_validation/coordinator/config.py
+++ b/uptime_service_validation/coordinator/config.py
@@ -31,12 +31,15 @@ class Config:
     VALID_STORAGE_OPTIONS = [STORAGE_CASSANDRA, STORAGE_POSTGRES]
     SUBMISSION_STORAGE = os.getenv("SUBMISSION_STORAGE", STORAGE_POSTGRES).upper()
 
-    # Postgres
-    POSTGRES_HOST = os.environ["POSTGRES_HOST"]
-    POSTGRES_DB = os.environ["POSTGRES_DB"]
-    POSTGRES_USER = os.environ["POSTGRES_USER"]
-    POSTGRES_PASSWORD = os.environ["POSTGRES_PASSWORD"]
-    POSTGRES_PORT = os.environ["POSTGRES_PORT"]
+    # Postgres. Read lazily (`.get()` instead of `[]`) so that importing
+    # this module doesn't require these to be set — useful for tooling,
+    # smoke tests, and any context that doesn't actually run the
+    # coordinator. `Config.validate()` enforces presence at startup.
+    POSTGRES_HOST = os.environ.get("POSTGRES_HOST")
+    POSTGRES_DB = os.environ.get("POSTGRES_DB")
+    POSTGRES_USER = os.environ.get("POSTGRES_USER")
+    POSTGRES_PASSWORD = os.environ.get("POSTGRES_PASSWORD")
+    POSTGRES_PORT = os.environ.get("POSTGRES_PORT")
     POSTGRES_SSLMODE = os.environ.get("POSTGRES_SSLMODE", "require")
 
     # Cassandra / Keyspaces
@@ -92,6 +95,28 @@ class Config:
         :return: True if the application should ignore the application status.
         """
         return bool_env_var_set("IGNORE_APPLICATION_STATUS")
+
+    @classmethod
+    def validate(cls):
+        """Raise ValueError if any required environment variable is missing.
+
+        Should be called at startup (e.g. from `coordinator.main()`)
+        before any subsystem that depends on these. The class-level reads
+        above use `.get()`, so missing values surface as `None` until
+        this method is called and reports them clearly.
+        """
+        required = {
+            "POSTGRES_HOST": cls.POSTGRES_HOST,
+            "POSTGRES_DB": cls.POSTGRES_DB,
+            "POSTGRES_USER": cls.POSTGRES_USER,
+            "POSTGRES_PASSWORD": cls.POSTGRES_PASSWORD,
+            "POSTGRES_PORT": cls.POSTGRES_PORT,
+        }
+        missing = [name for name, value in required.items() if not value]
+        if missing:
+            raise ValueError(
+                "Missing required environment variables: " + ", ".join(missing)
+            )
 
 
 def bool_env_var_set(env_var_name):

--- a/uptime_service_validation/coordinator/coordinator.py
+++ b/uptime_service_validation/coordinator/coordinator.py
@@ -420,6 +420,8 @@ def main():
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
 
+    Config.validate()
+
     if Config.SUBMISSION_STORAGE not in Config.VALID_STORAGE_OPTIONS:
         raise ValueError(
             f"Invalid storage option: {Config.SUBMISSION_STORAGE}. Valid options are {Config.VALID_STORAGE_OPTIONS}"


### PR DESCRIPTION
## Summary

`Config.POSTGRES_HOST = os.environ["POSTGRES_HOST"]` (and four sibling lines) executed eagerly at module-import time. Any context that imported `Config` without first setting those env vars — CI smoke tests, REPL exploration, future component tests, even this repo's unit tests — crashed with `KeyError` before any code that actually used Postgres ran.

This PR makes the reads lazy and adds a single startup validation point:

- Switch the five `os.environ[...]` reads to `os.environ.get(...)`. Missing values surface as `None`.
- Add `Config.validate()` that raises one `ValueError` listing all missing required vars with a clear message.
- Call `Config.validate()` early in `coordinator.main()`, so production behavior is unchanged: misconfiguration still fails fast at startup, just from a controllable entrypoint and with a more actionable message than `KeyError: 'POSTGRES_HOST'`.

## Side effect: cleaner test setup

`tests/__init__.py` had been pre-setting all the POSTGRES_* env vars purely to dodge the import-time crash. Those lines are now redundant and removed. Other env defaults switched from `=` to `setdefault` so callers can still override them. All 16 existing unit tests still pass.

## Why this matters

This blocks PR #8 (image smoke tests) from doing a clean module-import smoke without dummy `-e POSTGRES_HOST=x` arguments. Once this lands, that PR can simplify. Same will hold for the upcoming component-test PR.

## Test plan

- [x] `poetry run pytest` — 16 passed (without setting any POSTGRES_* env vars)
- [x] Manual: `python -c "from uptime_service_validation.coordinator import coordinator"` succeeds in a fresh env
- [x] Manual: calling `Config.validate()` with empty env raises `ValueError` listing all five missing vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)