### PR TITLE
Update stale README references after MinaFoundation→o1-labs migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Uptime Service Validation
 
-[![CI](https://github.com/MinaFoundation/uptime-service-validation/actions/workflows/ci.yaml/badge.svg)](https://github.com/MinaFoundation/uptime-service-validation/actions/workflows/ci.yaml)
+[![CI](https://github.com/o1-labs/uptime-service-validation/actions/workflows/ci.yaml/badge.svg)](https://github.com/o1-labs/uptime-service-validation/actions/workflows/ci.yaml)
 
 ## Overview
 
 This repository is home for Validator/Coordinator component for Mina Delegation Program.
-This component is responsible for taking submissions data gathered by [uptime-service-backend](https://github.com/MinaFoundation/uptime-service-backend) and running validation against them using [stateless-verification-tool](https://github.com/MinaProtocol/mina/pull/14593). Next, based on these validation results, the Coordinator builds its own database containing uptime score.
+This component is responsible for taking submissions data gathered by [uptime-service-backend](https://github.com/o1-labs/uptime-service-backend) and running validation against them using [stateless-verification-tool](https://github.com/MinaProtocol/mina/pull/14593). Next, based on these validation results, the Coordinator builds its own database containing uptime score.
 
 **Important note:** If block producer submits at least one valid submission within the validation batch, it will be granted one point. There is a table `points_summary` that is instrumental for calculating scores. It is updated by a database trigger on every insert to the `points` table. While `points` table 
 holds one point for each valid submission, the `points_summary` holds only one point if at least one submission happened in the batch. This is crucial for keeping correct score percentage.
@@ -22,7 +22,7 @@ holds one point for each valid submission, the `points_summary` holds only one p
 1. **Install dependencies:**
 
 ```sh
-git clone https://github.com/MinaFoundation/uptime-service-validation.git
+git clone https://github.com/o1-labs/uptime-service-validation.git
 cd uptime-service-validation
 
 poetry install


### PR DESCRIPTION
## Summary

Three stale references in `README.md` left over from the MinaFoundation→o1-labs migration:

1. **CI badge** — pointed at the archived MinaFoundation workflow runs, so it never reflected this fork's actual state.
2. **Backend repo link** in the overview paragraph.
3. **Clone URL** in the getting-started instructions.

Same shape as the cleanup we did in [`uptime-service-backend`](https://github.com/o1-labs/uptime-service-backend) (PR #10 there).

## Test plan

- [x] `git diff` shows only the three intended URL changes
- [ ] After merge: badge resolves to live status against `o1-labs/uptime-service-validation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)